### PR TITLE
There are tags now, link to amphp tag only

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ A non-blocking concurrency framework for PHP applications.
 
 - GitHub: [amphp](https://github.com/amphp)
 - Website: [amphp.org](http://amphp.org)
-- [Amphp series](http://blog.kelunik.com/) by Niklas Keller / kelunik
+- [amphp blog series](http://blog.kelunik.com/tags/amphp.html) by Niklas Keller / kelunik
 
 ### Async PHP
 


### PR DESCRIPTION
I introduced tags in my blog now, so things like this can be linked properly.
