### PR TITLE
Update swoole URL to correct address

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Cooperative multitasking for PHP via coroutines.
 Asynchronous concurrent distributed networking framework for PHP
 
 - GitHub: [swoole](https://github.com/swoole)
-- Website: [swoole.com](http://www.swoole.com)
+- Website: [swoole.co.uk](https://www.swoole.co.uk)
 
 ## Repositories
 


### PR DESCRIPTION
This PR updates the Swoole ULR from http://www.swoole.com to the correct https://www.swoole.co.uk